### PR TITLE
Re-render to get `BINSTAR_TOKEN` in `.travis.yml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ env:
     - CONDA_PY=27
     - CONDA_PY=34
     - CONDA_PY=35
+  global:
+    # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
+    - secure: "AXX86ZlZUUy9sKYuUbiRMzbpzu+lWwyvMgZmiGkFQ/LK7EaF5NTVEVsIs6zOSvBH75tncexRym001USHqZRL9ac6+ZlMwxMttevDd014hJ5A/llxlfCvqsWiEO0FYKGoPYOYI73uTAWpVs4N3pWlI+0yrBo36nHS1sM9iIvTg2VGicwXcsJ+SAffpf3rAnV7OkPkh7FpAjyaixqcM/g8aqQLTlT8x2ZYjBUkIAKRVGhc0vHzUNyXcmeKJTlR9uNQYDpZYlc/q7AmvRflPA4oMk9CaMDvHRUzCKM0AW/wBlYay/0GiycyJ2+uDstBbNrwNgfXjNdivTNaTQN9pY7W3WFnoiABItalW27Yhb1PMM/mRmzY/L6N7zfjpB4Zgf4JCjh5tHOEL/e2CKRnRsGansv1FkXPI2w0AiBHbUhZZfk+reB8hzOn9QLKQDB6NiXf7NLOq3Ee3UCbnjLoqBHI94PcAXR9xI5cbVSOL50wRmDlfc2w/94DBCkpTTaQeILlTPIb9wlJptVD4lcfR+2MYHG+JISVxbsQtfUmXomweBLOn484POAvFCMZ9OaxIXzo+F7NobcqoMSbr5kk2CGj6MMcEylk1dgBM1SIWbTUcrP4YLnYt/CcZxH5jUxGBnUowMTeNm8cvQ3sVR/2H5kdkAlTEPmoX2MNZ+Jb2Pv0kXA="
 
 
 before_install:


### PR DESCRIPTION
Fixes https://github.com/conda-forge/waf-feedstock/issues/1

Re-renders with `conda-smithy` to get the `BINSTAR_TOKEN` in `.travis.yml`.
